### PR TITLE
fix: change depcreated function

### DIFF
--- a/module_utils/smc_util.py
+++ b/module_utils/smc_util.py
@@ -176,7 +176,7 @@ def get_method_argspec(clazz, method=None):
 
     :rtype: tuple
     """
-    argspec = inspect.getargspec(getattr(clazz, method if method else 'create'))
+    argspec = inspect.getfullargspec(getattr(clazz, method if method else 'create'))
     valid_args = argspec.args[1:]
     args = []
     if argspec.defaults:


### PR DESCRIPTION
Since python3.11 the function `getargspec` from the inspect module is deprecated.

This commit fixes this behavior for newer python versions