### PR TITLE
Add support for subpolicies in firewall_rule_facts

### DIFF
--- a/library/firewall_rule_facts.py
+++ b/library/firewall_rule_facts.py
@@ -165,6 +165,7 @@ from ansible.module_utils.smc_util import ForcepointModuleBase
 try:
     from smc.api.exceptions import SMCException
     from smc.policy.layer3 import FirewallPolicy
+    from smc.policy.layer3 import FirewallSubPolicy
 except ImportError:
     pass
 
@@ -277,7 +278,8 @@ class FirewallRuleFacts(ForcepointModuleBase):
         
         rules = []
         try:
-            policy = self.search_by_type(FirewallPolicy)
+            policy = self.search_by_type(FirewallPolicy) or \
+                     self.search_by_type(FirewallSubPolicy)
             if not policy:
                 self.fail(msg='Policy specified could not be found: %s' % self.filter)
             elif len(policy) > 1:


### PR DESCRIPTION
The current firewall_rule_facts module does not query Sub-Policies. Therefore this PR will add this behavior by having the module try searching in type FirewallSubPolicy if FirewallPolicy does not return any elements.

I've also noticed that neither this fact module, nor the corresponding firewall_rule module have support for IPv6 policy rules. Support for this should not be too hard to add either, though it depends on how you would want it implemented. E.g. as a module argument to switch between IPv4 and IPv6 queries or, when possible, query both depending on the "typeof" variable of the policy object the module found?